### PR TITLE
fix: Give control over output

### DIFF
--- a/crates/cargo-crate-api/src/main.rs
+++ b/crates/cargo-crate-api/src/main.rs
@@ -78,8 +78,10 @@ fn run() -> proc_exit::ExitResult {
 }
 
 fn dump_raw(pkg: &cargo_metadata::Package, format: args::Format) -> Result<(), eyre::Report> {
-    let raw =
-        crate_api::RustDocBuilder::new().dump_raw(pkg.manifest_path.as_path().as_std_path())?;
+    let colored_stderr = concolor_control::get(concolor_control::Stream::Stderr).color();
+    let raw = crate_api::RustDocBuilder::new()
+        .color(colored_stderr)
+        .dump_raw(pkg.manifest_path.as_path().as_std_path())?;
     let raw: rustdoc_json_types_fork::Crate = serde_json::from_str(&raw)?;
 
     let manifest = crate_api::manifest::Manifest::from(pkg);
@@ -113,8 +115,10 @@ fn dump_raw(pkg: &cargo_metadata::Package, format: args::Format) -> Result<(), e
 }
 
 fn api(pkg: &cargo_metadata::Package, format: args::Format) -> Result<(), eyre::Report> {
-    let mut api =
-        crate_api::RustDocBuilder::new().into_api(pkg.manifest_path.as_path().as_std_path())?;
+    let colored_stderr = concolor_control::get(concolor_control::Stream::Stderr).color();
+    let mut api = crate_api::RustDocBuilder::new()
+        .color(colored_stderr)
+        .into_api(pkg.manifest_path.as_path().as_std_path())?;
 
     let manifest = crate_api::manifest::Manifest::from(pkg);
     manifest.into_api(&mut api);
@@ -144,13 +148,17 @@ fn diff(
     base: report::Source,
     format: args::Format,
 ) -> Result<(), eyre::Report> {
-    let mut after =
-        crate_api::RustDocBuilder::new().into_api(pkg.manifest_path.as_path().as_std_path())?;
+    let colored_stderr = concolor_control::get(concolor_control::Stream::Stderr).color();
+    let mut after = crate_api::RustDocBuilder::new()
+        .color(colored_stderr)
+        .into_api(pkg.manifest_path.as_path().as_std_path())?;
     let manifest = crate_api::manifest::Manifest::from(pkg);
     manifest.into_api(&mut after);
 
     let base_path = resolve_source_path(metadata, pkg, &base)?;
-    let mut before = crate_api::RustDocBuilder::new().into_api(&base_path)?;
+    let mut before = crate_api::RustDocBuilder::new()
+        .color(colored_stderr)
+        .into_api(&base_path)?;
     let old_pkg = resolve_package(&base_path)?;
     let manifest = crate_api::manifest::Manifest::from(&old_pkg);
     manifest.into_api(&mut before);

--- a/crates/crate-api/src/rustdoc.rs
+++ b/crates/crate-api/src/rustdoc.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 pub struct RustDocBuilder {
     deps: bool,
     target_directory: Option<std::path::PathBuf>,
+    silence: bool,
 }
 
 impl RustDocBuilder {
@@ -12,6 +13,7 @@ impl RustDocBuilder {
         Self {
             deps: false,
             target_directory: None,
+            silence: false,
         }
     }
 
@@ -33,6 +35,12 @@ impl RustDocBuilder {
 
     pub fn target_directory(mut self, path: impl Into<std::path::PathBuf>) -> Self {
         self.target_directory = Some(path.into());
+        self
+    }
+
+    /// Don't write progress to stderr
+    pub fn silence(mut self, yes: bool) -> Self {
+        self.silence = yes;
         self
     }
 
@@ -77,36 +85,46 @@ impl RustDocBuilder {
             manifest_target_directory.as_path()
         };
 
+        let stderr = if self.silence {
+            std::process::Stdio::piped()
+        } else {
+            // Print cargo doc progress
+            std::process::Stdio::inherit()
+        };
+
         let mut cmd = std::process::Command::new("cargo");
         cmd.env(
             "RUSTDOCFLAGS",
             "-Z unstable-options --document-hidden-items --output-format=json",
         )
         .stdout(std::process::Stdio::null()) // Don't pollute cargo api output
-        .stderr(std::process::Stdio::inherit()) // Print cargo doc progress
+        .stderr(stderr)
         .args(["+nightly", "doc", "--all-features"])
         .arg("--manifest-path")
         .arg(manifest_path)
         .arg("--target-dir")
         .arg(target_dir);
         if !self.deps {
-            // HACK: Trying to reduce chance of hitting
-            // - rust-lang/rust#89097
-            // - rust-lang/rust#83718
             cmd.arg("--no-deps");
         }
 
-        let status = cmd
-            .status()
+        let output = cmd
+            .output()
             .map_err(|e| crate::Error::new(crate::ErrorKind::ApiParse, e))?;
-        if !status.success() {
-            return Err(crate::Error::new(
-                crate::ErrorKind::ApiParse,
+        if !output.status.success() {
+            let message = if self.silence {
+                format!(
+                    "Failed when running cargo-doc on {}: {}",
+                    manifest_path.display(),
+                    String::from_utf8_lossy(&output.stderr)
+                )
+            } else {
                 format!(
                     "Failed when running cargo-doc on {}. See stderr.",
                     manifest_path.display(),
-                ),
-            ));
+                )
+            };
+            return Err(crate::Error::new(crate::ErrorKind::ApiParse, message));
         }
 
         let json_path = target_dir.join(format!("doc/{}.json", crate_name));

--- a/crates/crate-api/src/rustdoc.rs
+++ b/crates/crate-api/src/rustdoc.rs
@@ -6,6 +6,7 @@ pub struct RustDocBuilder {
     deps: bool,
     target_directory: Option<std::path::PathBuf>,
     silence: bool,
+    color: Option<bool>,
 }
 
 impl RustDocBuilder {
@@ -14,6 +15,7 @@ impl RustDocBuilder {
             deps: false,
             target_directory: None,
             silence: false,
+            color: None,
         }
     }
 
@@ -41,6 +43,12 @@ impl RustDocBuilder {
     /// Don't write progress to stderr
     pub fn silence(mut self, yes: bool) -> Self {
         self.silence = yes;
+        self
+    }
+
+    /// Whether stderr can be colored
+    pub fn color(mut self, yes: impl Into<Option<bool>>) -> Self {
+        self.color = yes.into();
         self
     }
 
@@ -106,6 +114,13 @@ impl RustDocBuilder {
         .arg(target_dir);
         if !self.deps {
             cmd.arg("--no-deps");
+        }
+        if let Some(color) = self.color {
+            if color {
+                cmd.arg("--color=always");
+            } else {
+                cmd.arg("--color=never");
+            }
         }
 
         let output = cmd


### PR DESCRIPTION
This gives the caller control over whether to output progress when gathering documentation and to have the colored output match the rest of the application.